### PR TITLE
Added draft implementation of Bound base class and NormBound

### DIFF
--- a/Core/Bounds/BoundBase.hpp
+++ b/Core/Bounds/BoundBase.hpp
@@ -1,0 +1,99 @@
+//----------------------------------------------------------------------------------------------------
+// File: BoundBase.hpp
+// Desc: base class for bounds
+//----------------------------------------------------------------------------------------------------
+#pragma once
+
+// Standard libraries includes
+#include <algorithm>
+#include <type_traits>
+#include <memory>
+
+// Third-party dependencies
+#include <Eigen/Dense>
+
+namespace gtfo {
+
+template <unsigned int Dimensions, typename Scalar>
+class BoundExpression{
+
+    static_assert(Dimensions > 0, "Dimensions must be at least 1.");
+    static_assert(std::is_floating_point_v<Scalar>, "Template argument Scalar must be a floating-point type.");
+
+    using VectorN = Eigen::Matrix<Scalar, Dimensions, 1>;
+    using BoundPtr = std::shared_ptr<const BoundExpression>;
+
+private:
+    enum class Relation{
+        Union,
+        Intersection
+    };
+
+public:
+    BoundExpression()
+        :   relation_(Relation::Union) {}
+
+    BoundExpression(const Relation& relation)
+        :   relation_(relation){}
+
+    BoundExpression(const BoundExpression& bound_expression) = default;
+
+    template <typename DerivedA, typename DerivedB>
+    friend BoundExpression operator&(const DerivedA& lhs, const DerivedB& rhs){
+        static_assert(std::is_base_of_v<BoundExpression, DerivedA> && std::is_base_of_v<BoundExpression, DerivedB>, "BoundExpression::operator& template arguments need to be a BoundExpression or a derived class of Bound");
+        BoundExpression expression(Relation::Intersection);
+        expression.tree_.push_back(std::make_shared<DerivedA>(lhs));
+        expression.tree_.push_back(std::make_shared<DerivedB>(rhs));
+        return expression;
+    }
+
+    template <typename DerivedA, typename DerivedB>
+    friend BoundExpression operator|(const DerivedA& lhs, const DerivedB& rhs){
+        static_assert(std::is_base_of_v<BoundExpression, DerivedA> && std::is_base_of_v<BoundExpression, DerivedB>, "BoundExpression::operator| template arguments need to be a BoundExpression or a derived class of Bound");
+        BoundExpression expression(Relation::Union);
+        expression.tree_.push_back(std::make_shared<DerivedA>(lhs));
+        expression.tree_.push_back(std::make_shared<DerivedB>(rhs));
+        return expression;
+    }
+
+    virtual bool Contains(const VectorN& point) const {
+        assert(!tree_.empty());
+        if(relation_ == Relation::Union){
+            return std::any_of(tree_.begin(), tree_.end(), [&point](const BoundPtr& ptr){
+                return ptr->Contains(point);
+            });
+        } else{ // Relation::Intersection
+            return std::all_of(tree_.begin(), tree_.end(), [&point](const BoundPtr& ptr){
+                return ptr->Contains(point);
+            });
+        }
+    }
+
+    virtual VectorN operator()(const VectorN& point) const {
+        // TODO
+        return point;
+    }
+
+private:
+    Relation relation_;
+    std::vector<BoundPtr> tree_;
+};
+
+template <unsigned int Dimensions, typename Scalar = double>
+class BoundBase : public BoundExpression<Dimensions, Scalar>{
+public:
+    using VectorN = Eigen::Matrix<Scalar, Dimensions, 1>;
+    using BoundExpression = BoundExpression<Dimensions, Scalar>;
+
+    BoundBase() {}
+
+    virtual bool Contains(const VectorN& point) const override {
+        return true;
+    }
+
+    virtual VectorN operator()(const VectorN& point) const override {
+        return point;
+    }
+};
+
+}   // namespace gtfo

--- a/Core/Bounds/NormBound.hpp
+++ b/Core/Bounds/NormBound.hpp
@@ -1,0 +1,39 @@
+//----------------------------------------------------------------------------------------------------
+// File: NormBound.hpp
+// Desc: Norm bound derived class
+//----------------------------------------------------------------------------------------------------
+#pragma once
+
+// Project-specific
+#include "BoundBase.hpp"
+
+namespace gtfo {
+
+template <int Norm, unsigned int Dimensions, typename Scalar = double>
+class NormBound : public BoundBase<Dimensions, Scalar>{
+public:
+    static_assert(Norm >= 1 || Norm == -1, "Norm argument needs to be at least 1 or be -1");
+
+    NormBound(const Scalar& threshold)
+        :   threshold_(threshold)
+    {
+        assert(threshold > 0.0);
+    }
+
+    using VectorN = Eigen::Matrix<Scalar, Dimensions, 1>;
+
+    // The constant Eigen::Infinity, defined as -1, can be used for the infinite norm
+    bool Contains(const VectorN& point) const override {
+        return point.template lpNorm<Norm>() <= threshold_;
+    }
+
+    VectorN operator()(const VectorN& point) const override {
+        const Scalar norm = point.template lpNorm<Norm>();
+        return std::min(norm, threshold_) * point;
+    }
+
+private:
+    const Scalar threshold_;
+};
+
+}   // namespace gtfo

--- a/gtfo.hpp
+++ b/gtfo.hpp
@@ -7,3 +7,5 @@
 #include "Core/ModelArray.hpp"
 #include "Core/Models/PointMassFirstOrder.hpp"
 #include "Core/Models/PointMassSecondOrder.hpp"
+
+#include "Core/Bounds/NormBound.hpp"


### PR DESCRIPTION
# Bounds Implementation

I created a draft implementation of a base class for hard/soft bounds, as well as an example `NormBound`. The bound class allows arbitrary unions and intersections of compatible bounds, by overloading the bitwise OR (|) and AND (&) operators, respectively. The normal order of operations for union / intersection expressions is followed. 

An example:
```
gtfo::NormBound<2, 2> first_bound(10.0);
gtfo::NormBound<2, 2> second_bound(20.0);
gtfo::BoundBase<2> third_bound;

auto bounds = (first_bound | second_bound) & third_bound & (gtfo::NormBound<2,2>(7.0) | third_bound);
```
Right now, I've only implemented a `Contains` function, which checks if the resulting bound contains a particular point. The next step, which I marked as `TODO`, is to add the logic for finding the closest point within the bound for any given point, in the `operator()` overload. An additional helpful feature is to add a method for printing the resulting bound structure / hierarchy, which would be helpful for our planned visualizer. 