### PR TITLE
Implemented function operator overload and added center for norm bounds

### DIFF
--- a/Core/Bounds/NormBound.hpp
+++ b/Core/Bounds/NormBound.hpp
@@ -14,8 +14,11 @@ class NormBound : public BoundBase<Dimensions, Scalar>{
 public:
     static_assert(Norm >= 1 || Norm == -1, "Norm argument needs to be at least 1 or be -1");
 
-    NormBound(const Scalar& threshold)
-        :   threshold_(threshold)
+    using VectorN = Eigen::Matrix<Scalar, Dimensions, 1>;
+
+    NormBound(const Scalar& threshold, const VectorN& center = VectorN::Zero())
+        :   threshold_(threshold),
+            center_(center)
     {
         assert(threshold > 0.0);
     }
@@ -24,16 +27,24 @@ public:
 
     // The constant Eigen::Infinity, defined as -1, can be used for the infinite norm
     bool Contains(const VectorN& point) const override {
-        return point.template lpNorm<Norm>() <= threshold_;
+        return (point - center_).template lpNorm<Norm>() <= threshold_;
     }
 
-    VectorN operator()(const VectorN& point) const override {
-        const Scalar norm = point.template lpNorm<Norm>();
-        return std::min(norm, threshold_) * point;
+    VectorN operator()(const VectorN& point, const VectorN& prev_point, const Scalar& tol = 0.01) const override {
+        // An exact (and simple) solution exists in 1D
+        if constexpr(Dimensions == 1){
+            const VectorN point_shifted_origin = point - center_;
+            return std::min(point_shifted_origin.template lpNorm<Norm>(), threshold_) * point_shifted_origin.normalized() + center_;
+        } 
+        // Although exact solutions exist for specific cases, e.g. Norm = 2, Dimensions = 2, they are very complicated. It's easier to solve this numerically with the default implementation
+        else {
+            return BoundBase<Dimensions, Scalar>::operator()(point, prev_point, tol);
+        }
     }
 
 private:
     const Scalar threshold_;
+    const VectorN center_;
 };
 
 }   // namespace gtfo


### PR DESCRIPTION
## Changes
- Implemented overloaded function operator to determine if a new point is outside of the bounds
- Implemented a bisection search to numerically find the closest point inside the bounds
- Updated `NormBound` to have an exact solution for 1D systems
- Updated `NormBound` to be centered at any arbitrary location (default is origin)

## ToDo's
- Update the overloaded function operator to also provide unit normal information. This is necessary to reflect velocities back into the bound, i.e., prevent trajectories from getting stuck at the virtual boundaries
- Implement rectangular bounds
- Implement Soft Bounds wrapper 