### PR TITLE
Fixed issue with sign of velocity at hard bound

### DIFF
--- a/Core/Bounds/BoundBase.hpp
+++ b/Core/Bounds/BoundBase.hpp
@@ -154,12 +154,12 @@ public:
         return prev_point + scale_opt * difference_vector;
     }
 
-    [[nodiscard]] virtual VectorN GetNegativeSurfaceNormal(const VectorN& point) const {
+    [[nodiscard]] virtual VectorN GetSurfaceNormal(const VectorN& point) const {
         if(tree_.empty()){
             return VectorN::Zero();
         }
         if(tree_.size() == 1){
-            return tree_[0]->GetNegativeSurfaceNormal(point);
+            return tree_[0]->GetSurfaceNormal(point);
         }
 
         // Find the bounds for which the point is at the boundary
@@ -173,10 +173,10 @@ public:
             return VectorN::Zero();
         }
 
-        // Otherwise, return the average of the negative surface normal vectors
+        // Otherwise, return the average of the surface normal vectors
         VectorN sum = VectorN::Zero();
         for(const BoundPtr& ptr : on_boundary){
-            sum += ptr->GetNegativeSurfaceNormal(point);
+            sum += ptr->GetSurfaceNormal(point);
         }
         return sum / on_boundary.size();
     } 
@@ -251,7 +251,7 @@ public:
         return prev_point + scale_opt * difference_vector;
     }
 
-    [[nodiscard]] virtual VectorN GetNegativeSurfaceNormal(const VectorN& point) const override {
+    [[nodiscard]] virtual VectorN GetSurfaceNormal(const VectorN& point) const override {
         return VectorN::Zero();
     }
 };

--- a/Core/Bounds/NormBound.hpp
+++ b/Core/Bounds/NormBound.hpp
@@ -44,27 +44,27 @@ public:
         }
     }
 
-    [[nodiscard]] VectorN GetNegativeSurfaceNormal(const VectorN& point) const override {
+    [[nodiscard]] VectorN GetSurfaceNormal(const VectorN& point) const override {
         const VectorN point_shifted_origin = point - center_;
         // 1-norm: https://math.stackexchange.com/questions/1395699/differentiation-of-1-norm-of-a-vector
         if constexpr(Norm == 1){
             const VectorN derivative = point_shifted_origin.array().sign();
-            return -derivative.normalized();
+            return derivative.normalized();
         } 
         // 2-norm: https://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf
         else if constexpr(Norm == 2){
-            return -point_shifted_origin.normalized();
+            return point_shifted_origin.normalized();
         }
         // Infinity-norm: https://math.stackexchange.com/questions/2696519/finding-the-derivative-of-the-infinity-norm
         else if constexpr(Norm == Eigen::Infinity){
             constexpr Scalar tol = 0.0001;
             const VectorN derivative = ((point_shifted_origin.cwiseAbs().array() - point_shifted_origin.cwiseAbs().maxCoeff()).cwiseAbs() < tol).template cast<Scalar>() * point_shifted_origin.array().sign();
-            return -derivative.normalized();
+            return derivative.normalized();
         }
         // p-norm (p >= 1): https://math.stackexchange.com/questions/1482494/derivative-of-the-l-p-norm
         else {
             const VectorN derivative = (point_shifted_origin.cwiseAbs() / point_shifted_origin.template lpNorm<Norm>()).array().pow(Norm - 1) * point_shifted_origin.array().sign();
-            return -derivative.normalized();
+            return derivative.normalized();
         }
     }
 

--- a/Core/Models/PointMassBase.hpp
+++ b/Core/Models/PointMassBase.hpp
@@ -71,10 +71,10 @@ namespace gtfo
             velocity_ = new_state.row(1);
 
             if(hard_bound_.IsAtBoundary(position_)){
-                const VectorN negative_surface_normal = hard_bound_.GetNegativeSurfaceNormal(position_);
-                const Scalar inner_product = velocity_.dot(negative_surface_normal);
-                if(inner_product < 0.0){
-                    velocity_ += inner_product * negative_surface_normal;
+                const VectorN surface_normal = hard_bound_.GetSurfaceNormal(position_);
+                const Scalar inner_product = velocity_.dot(surface_normal);
+                if(inner_product > 0.0){
+                    velocity_ -= inner_product * surface_normal;
                 }
             }
 


### PR DESCRIPTION
Small update:
- Fixed direction of velocity at hard bounds
- Changed `GetNegativeSurfaceNormal` to `GetSurfaceNormal` 