### PR TITLE
Allow physical positions to be used by virtual model

### DIFF
--- a/Core/Models/PointMassBase.hpp
+++ b/Core/Models/PointMassBase.hpp
@@ -85,6 +85,23 @@ namespace gtfo
             acceleration_ = (velocity_ - state.row(1).transpose()) / parameters_.dt;
         }
 
+        // Provides functionality for setting the virtual position to a physical position,
+        // which allows for more accurate bounds behavior in case the underlying position
+        // controller of the robot is poor. If a physical position is to be used, this function
+        // should be called everytime before Step is called, since the position is used to
+        // check for bound violations.
+        // If the given position is valid (not violating any hard bounds), set the position 
+        // and return true. Otherwise, do not set the position and return false.
+        inline bool SetPosition(const VectorN& position)
+        {
+            if(hard_bound_.Contains(position)){
+                position_ = position;
+                return true;
+            } else {
+                return false;
+            }
+        }
+
         [[nodiscard]] inline const VectorN &GetPosition() const
         {
             return position_;


### PR DESCRIPTION
This PR adds functionality for allowing a physical position, instead of the virtual position, to be used during bound violation checks. There are two requirements:
1. If the two positions diverge, then the virtual position no longer makes any sense for further use and should be updated to match the physical position,
2. If no physical position is provided, then the virtual position should be used. 

To satisfy both of these requirements, I felt the simplest way was to just add a setter for position to `PointMassBase`. Then, if the user is providing a physical position, they just have to set the physical position each time. The `PointMassBase::SetPosition` function also validates the position argument by checking it against the hard bound, and only sets the position if the hard bound is not violated. A success flag is returned. This flag should be monitored by the user logic to dictate what happens if the physical position is outside a hard bound (e.g., due to controller overshoot). 
```
const bool success = system.SetPosition(my_physical_position);
if(!success){
    // handle case where the provided physical position is outside a hard bound
}
system.Step(my_input);
```
Also, I don't think it's a big deal if the physical position slightly violates a hard bound due to controller overshoot. The internal `position_` is always guaranteed to be within the bound, so in this scenario, velocities that further violate the bound will still be prevented because `position_` is stuck at the boundary. So, the physical position will not get worse, and only motions towards the interior of the bound will be permitted.

This PR is more of just brainstorming for now. Let me know your thoughts.