### PR TITLE
Modified acceleration calculation to avoid large impulses

### DIFF
--- a/Core/Models/PointMassBase.hpp
+++ b/Core/Models/PointMassBase.hpp
@@ -105,16 +105,14 @@ namespace gtfo
             // Step the dynamics to determine our next state
             const Eigen::Matrix<Scalar, 2, Dimensions> new_state = A_discrete_ * state + B_discrete_ * force_input.transpose();
             
-            // Update position and velocity
+            // Update states
             DynamicsModelBase::position_ = new_state.row(0);
             DynamicsModelBase::velocity_ = new_state.row(1);
+            this->UpdateAcceleration(force_input, state.row(1));
 
-            // Ensure the position and velocity bounds are satisfied
+            // Ensure the hard bounds are satisfied
             this->EnforceHardBound();
             this->EnforceVelocityLimit();
-
-            // Update acceleration for new state
-            DynamicsModelBase::acceleration_ = (DynamicsModelBase::velocity_ - state.row(1).transpose()) / parameters_.dt;
 
             // Return error state to user. TODO: Consider converting to int for allowing other error states
             return err;
@@ -122,6 +120,10 @@ namespace gtfo
 
     protected:
         virtual void SetStateTransitionMatrices(const Parameters &parameters) = 0;
+
+        virtual void UpdateAcceleration(const VectorN& force_input, const VectorN& previous_velocity){
+            DynamicsModelBase::acceleration_ = (DynamicsModelBase::velocity_ - previous_velocity) / parameters_.dt;
+        }
 
         Parameters parameters_;
         Parameters soft_start_parameters_;
@@ -132,7 +134,6 @@ namespace gtfo
     private:
         Scalar soft_start_duration_;
         Scalar soft_start_timer_;
-
     };
 
 } // namespace gtfo

--- a/Core/Models/PointMassSecondOrder.hpp
+++ b/Core/Models/PointMassSecondOrder.hpp
@@ -81,6 +81,11 @@ namespace gtfo{
             Base::B_discrete_ << (damping * dt - (static_cast<Scalar>(1.0) - exponent) * mass) / (damping * damping),
                 (static_cast<Scalar>(1.0) - exponent) / damping;
         }
+
+        // Calculate the acceleration using the continuous equations with the current velocity
+        void UpdateAcceleration(const VectorN& force_input, const VectorN& previous_velocity) override{
+            Base::acceleration_ = (-Base::parameters_.damping / Base::parameters_.mass) * Base::velocity_ + force_input / Base::parameters_.mass;
+        }
     };
 
 } // namespace gtfo

--- a/Tests/VelocityLimitTest.cpp
+++ b/Tests/VelocityLimitTest.cpp
@@ -38,7 +38,7 @@ TEST(VelocityLimitTest, NoLimit)
     EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Scalar((1 - inv_exp) * (inv_exp * (1 + inv_exp) + 1))));
 
     std::cout << "Final acceleration: " << system.GetAcceleration().transpose() << "\n";
-    EXPECT_TRUE(gtfo::IsEqual(system.GetAcceleration(), Scalar((1 - inv_exp) * (1 - (1 + inv_exp) * (1 - inv_exp)))));
+    EXPECT_TRUE(gtfo::IsEqual(system.GetAcceleration(), Scalar(-(1 - inv_exp) * (inv_exp * (1 + inv_exp) + 1) + 1)));
 }
 
 // Verifies that a limited velocity works correctly


### PR DESCRIPTION
- Moved acceleration calculation so that large impulses can be avoided. This happened when the velocity is modified at a hard bound. Now, the acceleration is computed before the hard bounds are computed
- `EnforceHardBound` and `EnforceVelocityLimit` are updated so that components of acceleration that cause velocity to further violate the bound are removed
- The second order model uses an exact equation to calculate acceleration, whereas the first order one still uses a backward difference