### PR TITLE
Removed soft bound assertion

### DIFF
--- a/Core/Models/DynamicsBase.hpp
+++ b/Core/Models/DynamicsBase.hpp
@@ -96,7 +96,6 @@ public:
             "Soft bound must derive from BoundBase"
         );
         soft_bound_ = std::make_shared<BoundType>(bound);
-        assert(soft_bound_->Contains(position_));
         soft_bound_spring_constant_ = spring_constant;
         soft_bound_damping_constant_ = damping_constant;
     }


### PR DESCRIPTION
In `DynamicsBase::SetSoftBound`, there is an assertion that the current position must be contained within the soft bound to be set:
```
assert(soft_bound_->Contains(position_));
```
While this makes sense for hard bounds, I don't think this is necessary for soft bounds because we rely on the violation of soft bounds to calculate restoring forces. So, this assertion feels a bit overly restrictive.