### PR TITLE
Require user to have Eigen and Mujoco already installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,11 @@
 #----------------------------------------------------------------------------------------------------
 # File: CMakeLists.txt
-# Date: 12/03/2022
 # Desc: Top level CMake configuration file for the gtfo project
 # Usage: Configure this file appropriately. Then in the top level directory:
 #           `mkdir build`
 #           `cd build`
 #           `cmake ..` 
-#           `cmake --build . -j4`
+#           `cmake --build .`
 #       Tests can be invoked by calling either:
 #           `ctest` to run all the tests
 #           `ctest -R YourTestName` to run a specific test
@@ -21,24 +20,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Generate compile commands for clangd
 set(CMAKE_EXPORT_COMPILE_COMMANDS true)
 
-# Sets the install prefix dirctory. Otherwise, pass in to cmake through the -DCMAKE_INSTALL_PREFIX flag on the command line
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH ${CMAKE_SOURCE_DIR} FORCE)
-endif()
-
-# Sets an absolute install path
-set(INSTALL_PATH ${CMAKE_INSTALL_PREFIX}/bin)
-
 #----------------------------------------------------------------------------------------------------
 # Third party libraries
 #----------------------------------------------------------------------------------------------------
 # Eigen 3.4.0
-include_directories(${PROJECT_SOURCE_DIR}/External/eigen)
+find_package(Eigen3 3.4 REQUIRED NO_MODULE)
 
 # MuJoCo 2.3.1
-set(mujoco_DIR ${PROJECT_SOURCE_DIR}/External/mujoco/bin)
-find_package(mujoco PATHS ${mujoco_DIR} REQUIRED)
-include_directories(${mujoco_INCLUDE_DIR})
+find_package(mujoco 2.3.1 REQUIRED)
 
 #----------------------------------------------------------------------------------------------------
 # Project subdirectories

--- a/README.md
+++ b/README.md
@@ -4,31 +4,34 @@
 
 Written by the Bionics Lab at UCLA. This library is currently under development!
 
-## Initializing Submodules
-This project includes `Eigen` and `MuJoCo` as git submodules. To populate these dependencies, run the following command the first time:
+## Third-party Libraries
+This project requires `Eigen` version `3.4.0` and `MuJoCo` version `2.3.1` as dependencies. Ensure that they are already installed on your computer. If not, they are included as submodules for convenience, which can be populated using the command below:
 ```
 git submodule update --init --recursive
 ```
+After populating them, follow their instructions to install them.
 
-## Building Third-party Libraries
-As `Eigen` is a header-only, only `MuJoCo` needs to be built before using. In the `External/mujoco` directory:
-```
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=../bin
-cmake --build . -j4
-cmake --install .
-```
-
-## Building Tests
+## Building and Running Tests
 Tests and be built with the following commands:
 ```
 mkdir build
 cd build
 cmake ..
-cmake --build . -j4
+cmake --build . -j8
 ```
-They can then be executed with the following command in the `build` directory:
+Note that if your third-party dependencies are installed in non-default locations, you can specify them when you first call `cmake` with:
+```
+cmake .. -DCMAKE_PREFIX_PATH=<your first location>:<your second location>:<etc>
+```
+After building, tests can then be executed with the following command in the `build` directory:
 ```
 ctest
 ```
+To run a specific testsuite (`NormBoundTest` for example) and output upon failure, run:
+```
+ctest -R NormBoundTest --output-on-failure
+```
+A specific test within the testsuite can also be run with:
+```
+ctest -R NormBoundTest.Contains1D --output-on-failure
+``` 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,8 +1,7 @@
 #----------------------------------------------------------------------------------------------------
 # File: Tests/CMakeLists.txt
-# Date: 12/03/2022
 # Desc: CMakeList for test files
-# Usage: Each time a new test file is added, simply run `cmake --build . -j4` in the build directory again.
+# Usage: Each time a new test file is added, simply run `cmake --build .` in the build directory again.
 #        Tests can be executed by running `ctest` in the build directory
 #        Specific tests can be executed by running `ctest -R YourTestName`
 #----------------------------------------------------------------------------------------------------
@@ -38,6 +37,7 @@ add_executable(
 target_link_libraries(
     ${PROJECT_NAME}
     GTest::gtest_main
+    Eigen3::Eigen
     mujoco::mujoco
 )
 


### PR DESCRIPTION
To prevent issues of users having multiple versions of the third-party libraries installed, this change removes the duplicates from `gtfo` and relies on the user to provide `Eigen` and `Mujoco`. This should be a cleaner solution, because I think it is reasonable to assume that users of `gtfo` would already have these other libraries in their project.