### PR TITLE
Orientation and rigid body dynamics

### DIFF
--- a/Constraints/ManifoldConstraints.hpp
+++ b/Constraints/ManifoldConstraints.hpp
@@ -16,7 +16,7 @@
 
 // Project-specific
 #include "../Core/Utils/Constants.hpp"
-#include "../Core/Utils/UtilityFunctions.hpp"
+#include "../Core/Utils/Functions.hpp"
 
 namespace gtfo{
 template<unsigned int StateDimension, unsigned int ConstraintDimension, typename Scalar = double>

--- a/Constraints/ManifoldConstraints.hpp
+++ b/Constraints/ManifoldConstraints.hpp
@@ -16,6 +16,7 @@
 
 // Project-specific
 #include "../Core/Utils/Constants.hpp"
+#include "../Core/Utils/UtilityFunctions.hpp"
 
 namespace gtfo{
 template<unsigned int StateDimension, unsigned int ConstraintDimension, typename Scalar = double>

--- a/Core/Models/DynamicsBase.hpp
+++ b/Core/Models/DynamicsBase.hpp
@@ -35,6 +35,7 @@ public:
     using PositionBoundPtr = std::shared_ptr<PositionBound>;
 
     const static unsigned int Dimension = Dimensions; 
+    const static unsigned int PositionDimension = PositionDimensions; 
     const static bool Euclidean = (Dimensions == PositionDimensions);
 
     using ScalarType = Scalar;

--- a/Core/Models/Mujoco/Samples/rectangle.xml
+++ b/Core/Models/Mujoco/Samples/rectangle.xml
@@ -1,0 +1,30 @@
+<mujoco>
+    <compiler angle="radian"/>
+    <option timestep="0.01" gravity="0 0 0"/>
+
+    <worldbody>
+      <body pos="0 0 0" quat="1 0 0 0">
+        <inertial pos="0 0 0" xyaxes="1 0 0 0 1 0" mass="1.5" diaginertia="0.3 0.4 0.5"/>
+
+        <joint name="trans_x" type="slide" axis="1 0 0" damping="5"/>
+        <joint name="trans_y" type="slide" axis="0 1 0" damping="5"/>
+        <joint name="trans_z" type="slide" axis="0 0 1" damping="5"/>
+
+        <joint name="rot_x" type="hinge" axis="1 0 0" damping="2"/>
+        <joint name="rot_y" type="hinge" axis="0 1 0" damping="2"/>
+        <joint name="rot_z" type="hinge" axis="0 0 1" damping="2"/>
+
+        <geom type="box" size=".3 .2 .1" rgba="0.9 0 0 1"/>
+      </body>
+    </worldbody>
+
+    <actuator>
+        <motor name="trans_x" joint="trans_x"/>
+        <motor name="trans_y" joint="trans_y"/>
+        <motor name="trans_z" joint="trans_z"/>
+
+        <motor name="rot_x" joint="rot_x"/>
+        <motor name="rot_y" joint="rot_y"/>
+        <motor name="rot_z" joint="rot_z"/>
+    </actuator>
+</mujoco>

--- a/Core/Models/RigidBodySecondOrder.hpp
+++ b/Core/Models/RigidBodySecondOrder.hpp
@@ -79,7 +79,7 @@ public:
     {}
 
     [[nodiscard]] Pose<Scalar> GetPose(void) const{
-        return Pose(GetPosition());
+        return Pose(Base::GetPosition());
     }
 
     void SetPositionHardBound(const PositionBound& bound){

--- a/Core/Models/RigidBodySecondOrder.hpp
+++ b/Core/Models/RigidBodySecondOrder.hpp
@@ -1,0 +1,92 @@
+//----------------------------------------------------------------------------------------------------
+// File: RigidBodySecondOrder.hpp
+// Desc: Full rigid body dynamics
+//----------------------------------------------------------------------------------------------------
+#pragma once
+
+// Project-specific
+#include "DynamicsBase.hpp"
+#include "PointMassSecondOrder.hpp"
+#include "RotationSecondOrder.hpp"
+#include "../Containers/DynamicsVector.hpp"
+
+namespace gtfo
+{
+
+template<typename Scalar = double>
+class Pose{
+public:
+    using Position = Eigen::Matrix<Scalar, 3, 1>;
+    using Orientation = Eigen::Quaternion<Scalar>;
+
+    Pose(const Position& position, const Orientation& orientation)
+        :   position_(position),
+            orientation_(orientation)
+    {}
+
+    static Pose Identity(void){
+        return Pose(Position::Zero(), Orientation::Identity());
+    }
+    
+    [[nodiscard]] Position GetPosition(void) const{
+        return position_;
+    }
+
+    [[nodiscard]] Orientation GetOrientation(void) const{
+        return orientation_;
+    }
+
+    [[nodiscard]] Eigen::Matrix<Scalar, 4, 4> ToMatrix(void) const{
+        return (Eigen::Matrix<Scalar, 4, 4>() <<
+            orientation_.toRotationMatrix(), position_.transpose(),
+            Eigen::RowVector<Scalar, 4>::UnitW()
+        ).finished();
+    }
+
+private:
+    const Position position_;
+    const Orientation orientation_;
+};
+
+template<typename Scalar = double>
+class RigidBodySecondOrder : public DynamicsVector<PointMassSecondOrder<3, Scalar>, RotationSecondOrder<Scalar>>{
+public:
+    using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
+    using Base = DynamicsVector<PointMassSecondOrder<3, Scalar>, RotationSecondOrder<Scalar>>;
+    using PositionBound = BoundBase<3, Scalar>;
+    using Pose = Pose<Scalar>;
+
+    RigidBodySecondOrder(const Scalar& dt, const Scalar& mass, const Vector3& principal_inertia, const Scalar& translational_damping, const Scalar& rotational_damping, const Pose& initial_pose = Pose::Identity())
+        :   Base(
+                PointMassSecondOrder<3, Scalar>(
+                    SecondOrderParameters<Scalar>(
+                        dt, mass, translational_damping
+                    ), initial_pose.GetPosition()),
+                RotationSecondOrder<Scalar>(
+                    dt, principal_inertia, rotational_damping,
+                    initial_pose.GetOrientation())
+            )
+    {}
+
+    [[nodiscard]] Pose GetPose(void) const{
+        return Pose(GetPosition(), GetOrientation());
+    }
+
+    [[nodiscard]] Vector3 GetPosition(void) const{
+        return Base::template GetModel<0>().GetPosition();
+    }
+
+    [[nodiscard]] Vector3 GetOrientation(void) const{
+        return Base::template GetModel<1>().GetOrientation();
+    }
+
+    void SetPositionHardBound(const PositionBound& bound){
+        Base::template GetModel<0>().SetHardBound(bound);
+    }
+
+    void SetPositionSoftBound(const PositionBound& bound, const Scalar &spring_constant, const Scalar &damping_constant){
+        Base::template GetModel<0>().SetSoftBound(bound, spring_constant, damping_constant);
+    }
+};
+
+}

--- a/Core/Models/RigidBodySecondOrder.hpp
+++ b/Core/Models/RigidBodySecondOrder.hpp
@@ -24,6 +24,11 @@ public:
             orientation_(orientation)
     {}
 
+    Pose(const Eigen::Matrix<Scalar, 7, 1>& coeffs)
+        :   position_(coeffs.template head<3>()),
+            orientation_(coeffs.template tail<4>())
+    {}
+
     static Pose Identity(void){
         return Pose(Position::Zero(), Orientation::Identity());
     }
@@ -40,6 +45,12 @@ public:
         return (Eigen::Matrix<Scalar, 4, 4>() <<
             orientation_.toRotationMatrix(), position_.transpose(),
             Eigen::RowVector<Scalar, 4>::UnitW()
+        ).finished();
+    }
+
+    [[nodiscard]] Eigen::Matrix<Scalar, 7, 1> coeffs(void) const{
+        return (Eigen::Matrix<Scalar, 7, 1>() << 
+            position_, orientation_.coeffs()
         ).finished();
     }
 
@@ -68,15 +79,7 @@ public:
     {}
 
     [[nodiscard]] Pose<Scalar> GetPose(void) const{
-        return Pose(GetPosition(), GetOrientation());
-    }
-
-    [[nodiscard]] Vector3 GetPosition(void) const{
-        return Base::template GetModel<0>().GetPosition();
-    }
-
-    [[nodiscard]] Vector3 GetOrientation(void) const{
-        return Base::template GetModel<1>().GetOrientation();
+        return Pose(GetPosition());
     }
 
     void SetPositionHardBound(const PositionBound& bound){

--- a/Core/Models/RigidBodySecondOrder.hpp
+++ b/Core/Models/RigidBodySecondOrder.hpp
@@ -54,9 +54,8 @@ public:
     using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
     using Base = DynamicsVector<PointMassSecondOrder<3, Scalar>, RotationSecondOrder<Scalar>>;
     using PositionBound = BoundBase<3, Scalar>;
-    using Pose = Pose<Scalar>;
 
-    RigidBodySecondOrder(const Scalar& dt, const Scalar& mass, const Vector3& principal_inertia, const Scalar& translational_damping, const Scalar& rotational_damping, const Pose& initial_pose = Pose::Identity())
+    RigidBodySecondOrder(const Scalar& dt, const Scalar& mass, const Vector3& principal_inertia, const Scalar& translational_damping, const Scalar& rotational_damping, const Pose<Scalar>& initial_pose = Pose<Scalar>::Identity())
         :   Base(
                 PointMassSecondOrder<3, Scalar>(
                     SecondOrderParameters<Scalar>(
@@ -68,7 +67,7 @@ public:
             )
     {}
 
-    [[nodiscard]] Pose GetPose(void) const{
+    [[nodiscard]] Pose<Scalar> GetPose(void) const{
         return Pose(GetPosition(), GetOrientation());
     }
 

--- a/Core/Models/RotationSecondOrder.hpp
+++ b/Core/Models/RotationSecondOrder.hpp
@@ -1,0 +1,85 @@
+//----------------------------------------------------------------------------------------------------
+// File: RotationSecondOrder.hpp
+// Desc: rotational component of rigid body dynamics
+//----------------------------------------------------------------------------------------------------
+#pragma once
+
+// Third-party dependencies
+#include <Eigen/Geometry>
+
+// Project-specific
+#include "DynamicsBase.hpp"
+
+namespace gtfo
+{
+
+template<typename Scalar = double>
+class RotationSecondOrder : public DynamicsBase<3, Scalar, 4>{
+public:
+    using Base = DynamicsBase<3, Scalar, 4>;
+    using Vector3 = typename Base::VectorN;
+    using Matrix3 = Eigen::Matrix<Scalar, 3, 3>;
+    using Quaternion = Eigen::Quaternion<Scalar>;
+
+    RotationSecondOrder(const Scalar& dt, const Vector3& principal_inertia, const Scalar& damping, const Quaternion& initial_orientation = Quaternion::Identity())
+        :   Base(initial_orientation.coeffs()),
+            dt_(dt),
+            inertia_(principal_inertia.asDiagonal()),
+            damping_(damping)
+    {
+        assert(dt_ > 0.0);
+
+        // Positive definiteness
+        assert((principal_inertia.array() > 0.0).all());
+
+        // Triangle inequality
+        assert(principal_inertia[0] <= principal_inertia[1] + principal_inertia[2]);
+        assert(principal_inertia[1] <= principal_inertia[2] + principal_inertia[0]);
+        assert(principal_inertia[2] <= principal_inertia[0] + principal_inertia[1]);
+
+        // Passivity
+        assert(damping_ >= 0.0);
+    }
+
+    // Torque is in the body frame
+    void PropagateDynamics(const Vector3& torque) override{
+        // Compute and store the constant
+        static const Matrix3 inertia_inverse = inertia_.inverse();
+
+        // Propagate the body frame velocity with Euler's equations
+        Base::velocity_ = (Base::velocity_ + dt_ * inertia_inverse * (
+            -(Base::velocity_.cross(inertia_ * Base::velocity_))
+            -damping_ * Base::velocity_
+            + torque
+        )).eval();
+
+        // Current position interpreted as an orientation
+        Quaternion& orientation = Eigen::Map<Quaternion>(Base::position_.data());
+
+        // Assume the angular velocity is constant over the period and integrate it to get a delta position.
+        // Then, apply the delta transformation to update the body orientation
+        const Scalar speed = Base::velocity_.norm();
+        if(speed >= GTFO_EQUALITY_COMPARISON_TOLERANCE){
+            const Scalar angle = 0.5 * speed * dt_;
+            const Scalar scale = std::sin(angle) / speed;
+            const Quaternion delta(std::cos(angle), scale * Base::velocity_[0], scale * Base::velocity_[1], scale * Base::velocity_[2]);
+            orientation = (delta * orientation).normalized().eval();
+        }
+
+        // The following coarser approximation may work well for small timestamps.
+        // TODO: compare the two approaches
+        // orientation = (orientation + 0.5 * orientation * Base::velocity_ * dt_).normalized().eval();
+    }
+
+    // Calling GetPosition returns the quaternion as a Vector4
+    [[nodiscard]] inline Quaternion GetOrientation(void) const{
+        return Eigen::Map<Quaternion>(Base::position_.data());
+    }
+
+private:
+    const Scalar dt_;
+    const Matrix3 inertia_;
+    const Scalar damping_;
+};
+
+}

--- a/Core/Models/RotationSecondOrder.hpp
+++ b/Core/Models/RotationSecondOrder.hpp
@@ -9,7 +9,7 @@
 
 // Project-specific
 #include "DynamicsBase.hpp"
-
+#include "../Utils/UtilityFunctions.hpp"
 namespace gtfo
 {
 
@@ -56,11 +56,10 @@ public:
         // Current position interpreted as an orientation
         const Quaternion orientation(Base::position_.data());
 
-        // Integrate angular velocity over period to get a delta position transformation in axis-angle format
-        // Then, convert to a delta quaternion, using sin(x)/x being approximately 1 for small angles
-        const Scalar angle = Base::velocity_.norm() * dt_;
-        const Scalar scale = (angle >= GTFO_EQUALITY_COMPARISON_TOLERANCE) ? std::sin(angle / 2) / angle : 0.5;
-        const Quaternion delta(std::cos(angle / 2), Base::velocity_[0] * scale, Base::velocity_[1] * scale, Base::velocity_[2] * scale);
+        // Integrate angular velocity to get a delta quaternion transformation
+        const Scalar half_angle = 0.5 * dt_ * Base::velocity_.norm();
+        const Scalar scale = 0.5 * dt_ * sinc(half_angle);
+        const Quaternion delta(std::cos(half_angle), Base::velocity_[0] * scale, Base::velocity_[1] * scale, Base::velocity_[2] * scale);
         Base::position_ = (orientation * delta).normalized().coeffs();
     }
 

--- a/Core/Models/RotationSecondOrder.hpp
+++ b/Core/Models/RotationSecondOrder.hpp
@@ -62,10 +62,6 @@ public:
         const Scalar scale = (angle >= GTFO_EQUALITY_COMPARISON_TOLERANCE) ? std::sin(angle / 2) / angle : 0.5;
         const Quaternion delta(std::cos(angle / 2), Base::velocity_[0] * scale, Base::velocity_[1] * scale, Base::velocity_[2] * scale);
         Base::position_ = (orientation * delta).normalized().coeffs();
-
-        // The following coarser approximation may work well for small timestamps.
-        // TODO: compare the two approaches
-        // Base::position_ = (orientation + 0.5 * orientation * Base::velocity_ * dt_).normalized().coeffs();
     }
 
     // Calling GetPosition returns the quaternion as a Vector4

--- a/Core/Models/RotationSecondOrder.hpp
+++ b/Core/Models/RotationSecondOrder.hpp
@@ -61,7 +61,7 @@ public:
         const Scalar angle = Base::velocity_.norm() * dt_;
         const Scalar scale = (angle >= GTFO_EQUALITY_COMPARISON_TOLERANCE) ? std::sin(angle / 2) / angle : 0.5;
         const Quaternion delta(std::cos(angle / 2), Base::velocity_[0] * scale, Base::velocity_[1] * scale, Base::velocity_[2] * scale);
-        Base::position_ = (delta * orientation).normalized().coeffs();
+        Base::position_ = (orientation * delta).normalized().coeffs();
 
         // The following coarser approximation may work well for small timestamps.
         // TODO: compare the two approaches

--- a/Core/Models/RotationSecondOrder.hpp
+++ b/Core/Models/RotationSecondOrder.hpp
@@ -9,7 +9,7 @@
 
 // Project-specific
 #include "DynamicsBase.hpp"
-#include "../Utils/UtilityFunctions.hpp"
+#include "../Utils/Functions.hpp"
 namespace gtfo
 {
 
@@ -57,8 +57,8 @@ public:
         const Quaternion orientation(Base::position_.data());
 
         // Integrate angular velocity to get a delta quaternion transformation
-        const Scalar half_angle = 0.5 * dt_ * Base::velocity_.norm();
-        const Scalar scale = 0.5 * dt_ * sinc(half_angle);
+        const Scalar half_angle = Scalar(0.5) * dt_ * Base::velocity_.norm();
+        const Scalar scale = Scalar(0.5) * dt_ * sinc(half_angle);
         const Quaternion delta(std::cos(half_angle), Base::velocity_[0] * scale, Base::velocity_[1] * scale, Base::velocity_[2] * scale);
         Base::position_ = (orientation * delta).normalized().coeffs();
     }

--- a/Core/Utils/Comparisons.hpp
+++ b/Core/Utils/Comparisons.hpp
@@ -19,9 +19,4 @@ template <typename DerivedA, typename DerivedB>
     return ((a.derived() - b.derived()).array().abs() <= tol).all();
 }
 
-template <typename Scalar> 
-int sgn(Scalar val) {
-    return (Scalar(0) < val) - (val < Scalar(0));
-}
-
 }   // namespace gtfo

--- a/Core/Utils/Functions.hpp
+++ b/Core/Utils/Functions.hpp
@@ -1,5 +1,5 @@
 //----------------------------------------------------------------------------------------------------
-// File: UtiiltyFunctions.hpp
+// File: Functions.hpp
 // Desc: Utility class for math and simple functions
 //----------------------------------------------------------------------------------------------------
 #pragma once
@@ -21,7 +21,7 @@ int sgn(const Scalar& x) {
 template<typename Scalar>
 Scalar sinc(const Scalar& x){
     if(std::abs(x) < GTFO_EQUALITY_COMPARISON_TOLERANCE){
-        return 1.0 - x * x / 6.0;
+        return Scalar(1.0) - x * x / Scalar(6.0);
     } else{
         return std::sin(x) / x;
     }

--- a/Core/Utils/UtilityFunctions.hpp
+++ b/Core/Utils/UtilityFunctions.hpp
@@ -1,0 +1,30 @@
+//----------------------------------------------------------------------------------------------------
+// File: UtiiltyFunctions.hpp
+// Desc: Utility class for math and simple functions
+//----------------------------------------------------------------------------------------------------
+#pragma once
+
+// Third-party dependencies
+#include <Eigen/Dense>
+
+// Project-specific
+#include "Constants.hpp"
+
+namespace gtfo {
+
+template<typename Scalar> 
+int sgn(const Scalar& x) {
+    return (Scalar(0) < x) - (x < Scalar(0));
+}
+
+// Implements sin(x)/x by using a Taylor expansion near the origin
+template<typename Scalar>
+Scalar sinc(const Scalar& x){
+    if(std::abs(x) < GTFO_EQUALITY_COMPARISON_TOLERANCE){
+        return 1.0 - x * x / 6.0;
+    } else{
+        return std::sin(x) / x;
+    }
+}
+
+}   // namespace gtfo

--- a/README.md
+++ b/README.md
@@ -126,16 +126,18 @@ while(going_home){
     system.Step(...);
 }
 ```
-Switching between systems automatically updates the new system's state to the old one's at the time of the switch, so discontinuities are avoided. Since `DynamicsVector` and `DynamicsSelector` are both considered dynamics models, they can be nested within each other to any arbitrary degree. 
+Switching between systems automatically updates the new system's state to that of the old one at the time of the switch, so discontinuities are avoided. Since `DynamicsVector` and `DynamicsSelector` are both considered dynamics models, they can be nested within each other to any arbitrary degree. 
 ## Custom Dynamics
 In addition to the provided models:
-- `PointMassSecondOrder`: second-order mass-damper system
-- `PointMassFirstOrder`: first-order time-constant and dc-gain system
-- `HomingModel`: creates continuous homing trajectories with constant acceleration in first and last 10%
-- `ConstantVelocityModel`: constant velocity motions, useful for simple gui-commanded motions
-- `MujocoModel`: a MuJoCo-compatible model, which uses MuJoCo to propagate dynamics
+- `PointMassSecondOrder`: second-order mass-damper system,
+- `PointMassFirstOrder`: first-order time-constant and dc-gain system,
+- `RotationSecondOrder`: second-order rotational dynamics following Euler's equations, implemented with unit quaternions,
+- `RigidBodySecondOrder`: second-order rigid body dynamics driven with a wrench,
+- `HomingModel`: creates continuous homing trajectories with constant acceleration in first and last 10%,
+- `ConstantVelocityModel`: constant velocity motions, useful for simple gui-commanded motions,
+- `MujocoModel`: a MuJoCo-compatible model, which uses MuJoCo to propagate dynamics,
 
-custom models for your application can also be created. All dynamics models inherit from `gtfo::DynamicsBase`, so custom models should extend the class and override the `Step` function. 
+custom models for your application can also be created. All dynamics models inherit from `gtfo::DynamicsBase`, so custom models should extend the class and implement the `PropagateDynamics` function. 
 
 ## Settings Bounds
 `gtfo` allows for both soft and hard convex bounds to constrain the dynamics. The bound behavior (soft vs. hard) is independent of the bound's geometry. The `Core/Bounds` subdirectory contains two commonly used bound shapes: `NormBound` and `RectangleBound`.
@@ -165,7 +167,7 @@ system.SetSoftBound(norm_bound, spring_constant, damping_constant)
 ```
 A system does not require any bounds in order to operate. Typically, when both bound types are set, the soft bound is contained within the hard bound, otherwise the soft bound would never be reached.
 
-If more complex bound behaviors are desired, such as different types of bounds in different coordinates or the ability to dynamically switch between bounds, `DynamicsVector` and/or `DynamicsSelector` should be used:
+If more complex bound behaviors are desired, such as different types of bounds in different coordinates or the ability to dynamically switch between bounds, `DynamicsVector` and/or `DynamicsSelector` should be used. Note that bounds are applied to the individual models, and not at the container level.
 ```c++
 // Construct a system from two subsystems. Note that they are copied into system, so any bounds already associated with them are also copied
 gtfo::DynamicsSelector<

--- a/Tests/RigidBodyDynamicsTest.cpp
+++ b/Tests/RigidBodyDynamicsTest.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include <mujoco/mujoco.h>
+#include "gtfo.hpp"
+
+TEST(RigidBodyDynamicsTest, MujocoComparison)
+{   
+    using Vector3 = Eigen::Vector3d;
+    using Vector6 = Eigen::Matrix<double, 6, 1>;
+    using Quaternion = Eigen::Quaterniond;
+
+    // Load and create the MuJoCo model
+    EXPECT_TRUE(mjVERSION_HEADER == mj_version());
+    std::array<char, 1000> error;
+    mjModel* model = mj_loadXML("rectangle.xml", NULL, error.data(), 1000);
+    if(!model){
+        mju_error("Could not load model from file");
+    }
+    mjData* data = mj_makeData(model);
+    mj_step(model, data);
+
+    // Create the comparable gtfo model
+    gtfo::RigidBodySecondOrder<double> rigid_body(
+        model->opt.timestep,
+        model->body_mass[1],
+        Vector3::Map(&model->body_inertia[3]),
+        model->dof_damping[0],
+        model->dof_damping[3],
+        gtfo::Pose<double>(
+            Vector3::Map(&data->xpos[3]), 
+            Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]))
+    );
+
+    // Step the models together with the same input
+    const Vector6 input = (Vector6() << 0.3, -0.6, 0.0, 0.4, -0.5, 0.1).finished();
+    
+    Vector6::Map(data->ctrl) = input;
+    for(unsigned i = 0; i < 200; ++i){
+        mj_step(model, data);
+        rigid_body.Step(input);
+    }
+
+    // Evaluate that they are near each other
+    EXPECT_TRUE(gtfo::IsEqual(Vector3::Map(&data->xpos[3]), rigid_body.GetPose().GetPosition(), 0.002));
+    EXPECT_NEAR(Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]).angularDistance(rigid_body.GetPose().GetOrientation()), 0.0, M_PI / 36.0);
+}

--- a/Tests/RigidBodyDynamicsTest.cpp
+++ b/Tests/RigidBodyDynamicsTest.cpp
@@ -43,3 +43,92 @@ TEST(RigidBodyDynamicsTest, MujocoComparison)
     EXPECT_TRUE(gtfo::IsEqual(Vector3::Map(&data->xpos[3]), rigid_body.GetPose().GetPosition(), 0.002));
     EXPECT_NEAR(Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]).angularDistance(rigid_body.GetPose().GetOrientation()), 0.0, M_PI / 36.0);
 }
+
+TEST(RigidBodyDynamicsTest, DynamicsVector)
+{  
+    using Vector3 = Eigen::Vector3f;
+    using Vector6 = Eigen::Matrix<float, 6, 1>;
+    using Vector18 = Eigen::Matrix<float, 18, 1>;
+
+    // Create three standalong systems
+    gtfo::RigidBodySecondOrder<float> system1(0.1f, 3.0f, Vector3(0.001f, 0.002f, 0.003f), 0.4f, 0.6f);
+    gtfo::RigidBodySecondOrder<float> system2(0.05f, 1.0f, Vector3(0.003f, 0.001f, 0.002f), 0.2f, 0.0f);
+    gtfo::PointMassSecondOrder<6, float> system3(gtfo::SecondOrderParameters<float>(0.12f, 1.2f, 0.3f));
+
+    // Copy them into a vector
+    gtfo::DynamicsVector<
+        gtfo::RigidBodySecondOrder<float>,
+        gtfo::RigidBodySecondOrder<float>,
+        gtfo::PointMassSecondOrder<6, float>
+    > vector_system(system1, system2, system3);
+
+    // Propagate both and compare the states
+    const Vector6 input1 = (Vector6() << -0.1f, 0.0f, 0.1f, -0.1f, 0.1f, 3.2f).finished();
+    const Vector6 input2 = (Vector6() << 3.0f, 5.0f, -2.0f, 1.5f, -2.5f, 3.5f).finished();
+    const Vector6 input3 = (Vector6() << 0.0f, 0.0f, 0.3f, -0.3f, 0.0f, 0.25f).finished();
+
+    for(const Vector18& total_input : {
+        (Vector18() << input1, input2, input3).finished(),
+        (Vector18() << input2, input3, input1).finished(),
+        (Vector18() << input3, input1, input2).finished()
+    }){
+        system1.Step(total_input.head<6>());
+        system2.Step(total_input.segment<6>(6));
+        system3.Step(total_input.tail<6>());
+        vector_system.Step(total_input);
+
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetPosition().head<7>(), system1.GetPosition()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetOldPosition().head<7>(), system1.GetOldPosition()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetVelocity().head<6>(), system1.GetVelocity()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetAcceleration().head<6>(), system1.GetAcceleration()));
+
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetPosition().segment<7>(7), system2.GetPosition()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetOldPosition().segment<7>(7), system2.GetOldPosition()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetVelocity().segment<6>(6), system2.GetVelocity()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetAcceleration().segment<6>(6), system2.GetAcceleration()));
+
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetPosition().tail<6>(), system3.GetPosition()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetOldPosition().tail<6>(), system3.GetOldPosition()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetVelocity().tail<6>(), system3.GetVelocity()));
+        EXPECT_TRUE(gtfo::IsEqual(vector_system.GetAcceleration().tail<6>(), system3.GetAcceleration()));
+    }
+}
+
+TEST(RigidBodyDynamicsTest, DynamicsSelector)
+{
+    using Vector3 = Eigen::Vector3f;
+    using Vector6 = Eigen::Matrix<float, 6, 1>;
+
+    // Create two identical systems as well as a selector of the two
+    gtfo::RigidBodySecondOrder<float> system1(0.1f, 3.0f, Vector3(0.001f, 0.002f, 0.003f), 0.4f, 0.6f);
+    gtfo::RigidBodySecondOrder<float> system2(system1);
+
+    gtfo::DynamicsSelector<
+        gtfo::RigidBodySecondOrder<float>,
+        gtfo::RigidBodySecondOrder<float>
+    > selector_system(system1, system2);
+
+    // Step the first one and ensure that the second one's states are updated when it's selected
+    const Vector6 input1 = (Vector6() << -0.1f, 0.0f, 0.1f, -0.1f, 0.1f, 3.2f).finished();
+    system1.Step(input1);
+    system2.Step(input1);
+    selector_system.Step(input1);
+    selector_system.Select(1);
+
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetPosition(), system2.GetPosition()));
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetOldPosition(), system2.GetOldPosition()));
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetVelocity(), system2.GetVelocity()));
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetAcceleration(), system2.GetAcceleration()));
+
+    // Now repeat in the other direction
+    const Vector6 input2 = (Vector6() << 3.0f, 5.0f, -2.0f, 1.5f, -2.5f, 3.5f).finished();
+    system1.Step(input2);
+    system2.Step(input2);
+    selector_system.Step(input2);
+    selector_system.Select(0);
+
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetPosition(), system1.GetPosition()));
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetOldPosition(), system1.GetOldPosition()));
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetVelocity(), system1.GetVelocity()));
+    EXPECT_TRUE(gtfo::IsEqual(selector_system.GetAcceleration(), system1.GetAcceleration()));
+}

--- a/Tests/RotationalDynamicsTest.cpp
+++ b/Tests/RotationalDynamicsTest.cpp
@@ -58,3 +58,14 @@ TEST(RotationalDynamicsTest, Damping)
     EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
     EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
 }
+
+TEST(RotationalDynamicsTest, SmallAngleApproximation)
+{
+    gtfo::RotationSecondOrder<double> system(0.01, Eigen::Vector3d::Ones(), 0.0);
+    for(unsigned i = 0; i < 10000; ++i){
+        system.Step(Eigen::Vector3d(0.001, 0, 0));
+    }
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+    EXPECT_NEAR(system.GetOrientation().y(), 0.0, 1e-15);
+    EXPECT_NEAR(system.GetOrientation().z(), 0.0, 1e-15);
+}

--- a/Tests/RotationalDynamicsTest.cpp
+++ b/Tests/RotationalDynamicsTest.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include "gtfo.hpp"
+
+TEST(RotationalDynamicsTest, QuaternionStorage)
+{
+    const Eigen::Vector4d vector = Eigen::Vector4d(1.0, 2.0, 3.0, 4.0).normalized();
+    const Eigen::Quaterniond quaternion = Eigen::Quaterniond(vector);
+    const gtfo::RotationSecondOrder<double> system(0.1, Eigen::Vector3d::Ones(), 1.0, quaternion);
+
+    EXPECT_TRUE(gtfo::IsEqual(system.GetPosition(), vector));
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+    EXPECT_NEAR(system.GetOrientation().angularDistance(quaternion), 0.0, 1e-15);
+}
+
+TEST(RotationalDynamicsTest, RightAngleRotation)
+{
+    // System starts at the identity
+    gtfo::RotationSecondOrder<double> system(1.0, Eigen::Vector3d::Ones(), 0.0);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetPosition(), Eigen::Vector4d::UnitW()));
+
+    // Apply torque 90 degrees about X
+    system.Step(Eigen::Vector3d::UnitX() * M_PI_2);
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetOrientation().coeffs(), Eigen::Vector4d(std::sqrt(2) / 2, 0, 0, std::sqrt(2) / 2)));
+    EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d(M_PI_2, 0, 0)));
+
+    // Apply the opposite torque. Since implicit Euler is used, the position shouldn't advance
+    system.Step(-Eigen::Vector3d::UnitX() * M_PI_2);
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetOrientation().coeffs(), Eigen::Vector4d(std::sqrt(2) / 2, 0, 0, std::sqrt(2) / 2)));
+    EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
+
+    // Now rotate back to the original orientation
+    system.Step(Eigen::Vector3d::UnitX() * M_PI_2);
+    system.Step(Eigen::Vector3d::Zero());
+    system.Step(Eigen::Vector3d::Zero());
+    system.Step(-Eigen::Vector3d::UnitX() * M_PI_2);
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+    EXPECT_NEAR(system.GetOrientation().angularDistance(Eigen::Quaterniond::Identity()), 0.0, 1e-15);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
+}
+
+TEST(RotationalDynamicsTest, Damping)
+{
+    gtfo::RotationSecondOrder<double> system(0.01, Eigen::Vector3d::Ones(), 1.0);
+
+    // Accelerate the system
+    for(unsigned i = 0; i < 200; ++i){
+        system.Step(Eigen::Vector3d(1.0, 1.0, 0.0));
+    }
+    EXPECT_FALSE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+
+    // Let the system slow down by itself
+    for(unsigned i = 0; i < 1000; ++i){
+        system.Step(Eigen::Vector3d::Zero());
+    }
+    EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
+    EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
+}

--- a/Tests/RotationalDynamicsTest.cpp
+++ b/Tests/RotationalDynamicsTest.cpp
@@ -12,7 +12,7 @@ TEST(RotationalDynamicsTest, QuaternionStorage)
     EXPECT_NEAR(system.GetOrientation().angularDistance(quaternion), 0.0, 1e-15);
 }
 
-TEST(RotationalDynamicsTest, RightAngleRotation)
+TEST(RotationalDynamicsTest, RotateAround)
 {
     // System starts at the identity
     gtfo::RotationSecondOrder<double> system(1.0, Eigen::Vector3d::Ones(), 0.0);
@@ -37,6 +37,23 @@ TEST(RotationalDynamicsTest, RightAngleRotation)
     system.Step(-Eigen::Vector3d::UnitX() * M_PI_2);
     EXPECT_NEAR(system.GetOrientation().norm(), 1.0, 1e-15);
     EXPECT_NEAR(system.GetOrientation().angularDistance(Eigen::Quaterniond::Identity()), 0.0, 1e-15);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
+}
+
+TEST(RotationalDynamicsTest, RightAngleRotations)
+{
+    gtfo::RotationSecondOrder<double> system(1.0, Eigen::Vector3d::Ones(), 0.0);
+
+    // Rotate 90 degrees about X and stop
+    system.Step(Eigen::Vector3d::UnitX() * M_PI_2);
+    system.Step(-Eigen::Vector3d::UnitX() * M_PI_2);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetOrientation().coeffs(), Eigen::Vector4d(std::sqrt(2) / 2, 0, 0, std::sqrt(2) / 2)));
+    EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
+
+    // Now rotate 90 degrees about the body Y and stop
+    system.Step(Eigen::Vector3d::UnitY() * M_PI_2);
+    system.Step(-Eigen::Vector3d::UnitY() * M_PI_2);
+    EXPECT_TRUE(gtfo::IsEqual(system.GetOrientation().coeffs(), Eigen::Vector4d(0.5, 0.5, 0.5, 0.5)));
     EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), Eigen::Vector3d::Zero()));
 }
 

--- a/include/gtfo.hpp
+++ b/include/gtfo.hpp
@@ -11,6 +11,8 @@
 
 #include "../Core/Models/PointMassFirstOrder.hpp"
 #include "../Core/Models/PointMassSecondOrder.hpp"
+#include "../Core/Models/RotationSecondOrder.hpp"
+#include "../Core/Models/RigidBodySecondOrder.hpp"
 #include "../Core/Models/HomingModel.hpp"
 #include "../Core/Models/ConstantVelocityModel.hpp"
 #include "../Core/Models/Mujoco/MujocoModel.hpp"

--- a/include/gtfo.hpp
+++ b/include/gtfo.hpp
@@ -7,7 +7,7 @@
 #include "../Core/Utils/ClosestVector.hpp"
 #include "../Core/Utils/Constants.hpp"
 #include "../Core/Utils/Comparisons.hpp"
-#include "../Core/Utils/UtilityFunctions.hpp"
+#include "../Core/Utils/Functions.hpp"
 #include "../Core/Utils/Containers.hpp"
 
 #include "../Core/Models/PointMassFirstOrder.hpp"

--- a/include/gtfo.hpp
+++ b/include/gtfo.hpp
@@ -7,6 +7,7 @@
 #include "../Core/Utils/ClosestVector.hpp"
 #include "../Core/Utils/Constants.hpp"
 #include "../Core/Utils/Comparisons.hpp"
+#include "../Core/Utils/UtilityFunctions.hpp"
 #include "../Core/Utils/Containers.hpp"
 
 #include "../Core/Models/PointMassFirstOrder.hpp"


### PR DESCRIPTION
Added dynamics for orientation and rigid bodies. Specifically:
- Extended `DynamicsBase` so that position's dimension is not necessarily equal to velocity's (allows for dynamics on non-Euclidean surfaces, such as rotations)
- Added second-order orientation dynamics based on unit quaternions, and unit tests (we verified this one in the lab)
- Added rigid body dynamics, which is a `DynamicsVector` of a `PointMassSecondOrder` and `RotationSecondOrder`
- Added unit test by comparing rigid body dynamics to MuJoCo's 

Still need to verify the rigid body dynamics on the hardware.