### PR TITLE
MuJoCo dependent features included only if MuJoCo is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,12 +44,6 @@ find_package(Eigen3 3.4 REQUIRED NO_MODULE)
 
 # MuJoCo 2.3.1
 find_package(mujoco 2.3.1)
-if(mujoco_FOUND)
-    add_compile_definitions(MUJOCO_EXISTS)
-    message(STATUS "MuJoCo found. Including MuJoCo-dependent features.")
-else()
-    message(STATUS "MuJoCo not found. Skipping MuJoCo-dependent features.")
-endif()
 
 # osqp 0.6.2
 find_package(osqp REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,13 @@ option(GTFO_BUILD_TESTS "Build tests for GTFO" ON)
 find_package(Eigen3 3.4 REQUIRED NO_MODULE)
 
 # MuJoCo 2.3.1
-find_package(mujoco 2.3.1 REQUIRED)
+find_package(mujoco 2.3.1)
+if(mujoco_FOUND)
+    add_compile_definitions(MUJOCO_EXISTS)
+    message(STATUS "MuJoCo found. Including MuJoCo-dependent features.")
+else()
+    message(STATUS "MuJoCo not found. Skipping MuJoCo-dependent features.")
+endif()
 
 # osqp 0.6.2
 find_package(osqp REQUIRED)
@@ -60,9 +66,14 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 target_link_libraries(${PROJECT_NAME} INTERFACE
     ${CMAKE_DL_LIBS}
     Eigen3::Eigen
-    mujoco::mujoco
     osqp::osqpstatic
 )
+
+if(mujoco_FOUND)
+    target_link_libraries(${PROJECT_NAME} INTERFACE
+        mujoco::mujoco
+    )
+endif()
 
 #----------------------------------------------------------------------------------------------------
 # Testing

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Written by the [Bionics Lab](http://bionics.seas.ucla.edu/index.html) at UCLA.
 ## Installation
 
 ### Dependencies
-This project requires `Eigen` version `3.4.0`, `MuJoCo` version `2.3.1`, and `OSQP` version `0.6.2` as dependencies. Ensure that they are already installed on your computer. If not, their source code can be made available in the `External` subdirectory as git submodules after updating:
+This project requires `Eigen` version `3.4.0` and `OSQP` version `0.6.2` as dependencies. `MuJoCo` version `2.3.1` is an optional dependency, and if present, will enable additional features and tests. Ensure that the required dependencies are already installed on your computer. If not, their source code can be made available in the `External` subdirectory as git submodules after updating:
 ```
 git submodule update --init --recursive
 ```

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -28,6 +28,13 @@ file(GLOB_RECURSE TEST_FILES
     ${PROJECT_SOURCE_DIR}/*.cpp
 )
 
+# Remove the ones that depend on optional features
+if(NOT mujoco_FOUND)
+    list(REMOVE_ITEM TEST_FILES 
+        ${PROJECT_SOURCE_DIR}/MujocoModelTest.cpp
+    )
+endif()
+
 # Create the testing executables
 add_executable(
     ${PROJECT_NAME}
@@ -39,16 +46,18 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     gtfo
 )
 
-# Copy the MuJoCo runtime, which is only on Windows
-if(WIN32)
-    file(INSTALL ${mujoco_DIR}/../../../bin/mujoco.dll
-        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_DEPENDENT_OUTPUT_DIR}
-    )
-endif()
+if(mujoco_FOUND)
+    # Copy the MuJoCo runtime, which is only on Windows
+    if(WIN32)
+        file(INSTALL ${mujoco_DIR}/../../../bin/mujoco.dll
+            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_DEPENDENT_OUTPUT_DIR}
+        )
+    endif()
 
-# Copy the MuJoCo models to the test directory
-file(GLOB MUJOCO_MODELS ${CMAKE_SOURCE_DIR}/Core/Models/Mujoco/Samples/*.xml)
-file(INSTALL ${MUJOCO_MODELS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_DEPENDENT_OUTPUT_DIR})
+    # Copy the MuJoCo models to the test directory
+    file(GLOB MUJOCO_MODELS ${CMAKE_SOURCE_DIR}/Core/Models/Mujoco/Samples/*.xml)
+    file(INSTALL ${MUJOCO_MODELS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_DEPENDENT_OUTPUT_DIR})
+endif()
 
 # Automatically find all tests under the Google Test framework
 gtest_discover_tests(${PROJECT_NAME})

--- a/Tests/CMakeSmokeTest.cpp
+++ b/Tests/CMakeSmokeTest.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include <Eigen/Dense>
-#include <mujoco/mujoco.h>
 
 // Tests that the environment has been set up correctly 
 TEST(CMakeSmokeTest, BasicAssertions) {
@@ -12,10 +11,4 @@ TEST(CMakeSmokeTest, BasicAssertions) {
 // Verifies version information for Eigen
 TEST(CMakeSmokeTest, EigenVersion){
   EXPECT_TRUE(EIGEN_VERSION_AT_LEAST(3, 4, 0));
-}
-
-// Verifies that MuJoCo is compiled and linked correctly
-TEST(CMakeSmokeTest, MuJoCoVersion){
-  EXPECT_TRUE(mjVERSION_HEADER == mj_version());
-  EXPECT_EQ(mjVERSION_HEADER, 231);
 }

--- a/Tests/CollisionAvoidanceTest.cpp
+++ b/Tests/CollisionAvoidanceTest.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include "gtfo.hpp"
-#include <osqp.h>
 
 TEST(CollisionAvoidanceTest, Unconstrained)
 {

--- a/Tests/CollisionDetectionTest.cpp
+++ b/Tests/CollisionDetectionTest.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include "gtfo.hpp"
-#include <osqp.h>
 
 TEST(CollisionDetectionTest, PointToPoint)
 {

--- a/Tests/MujocoModelTest.cpp
+++ b/Tests/MujocoModelTest.cpp
@@ -1,8 +1,14 @@
 #include <gtest/gtest.h>
 #include "gtfo.hpp"
 
+// Verifies that MuJoCo is compiled and linked correctly
+TEST(CMakeSmokeTest, MuJoCoVersion){
+  EXPECT_TRUE(mjVERSION_HEADER == mj_version());
+  EXPECT_EQ(mjVERSION_HEADER, 231);
+}
+
 // Verifies that MujocoModel can be built
-TEST(MujocoBasicModelsTest, DataTypes)
+TEST(MujocoModelTest, DataTypes)
 {
     gtfo::MujocoModel<7, double> system_double("arms.xml", 1, 0.001);
     gtfo::MujocoModel<7, float> system_float("arms.xml", 1, 0.001f);
@@ -17,7 +23,7 @@ TEST(MujocoBasicModelsTest, DataTypes)
 }
 
 // Verifies that a model can be loaded and run
-TEST(MujocoBasicModelsTest, LoadArmsModel)
+TEST(MujocoModelTest, LoadArmsModel)
 {
     using VectorN = gtfo::MujocoModel<7>::VectorN;
     gtfo::MujocoModel<7> system("arms.xml", 1, 0.001);
@@ -37,7 +43,7 @@ TEST(MujocoBasicModelsTest, LoadArmsModel)
 }
 
 // Verifies rule-of-5 for MujocoModel and that there are no segfaults
-TEST(MujocoBasicModelsTest, RuleOfFive)
+TEST(MujocoModelTest, RuleOfFive)
 {
     using Wrapper = gtfo::MujocoModel<7>;
 
@@ -61,7 +67,7 @@ TEST(MujocoBasicModelsTest, RuleOfFive)
 }
 
 // Verifies that pausing works
-TEST(MujocoBasicModelsTest, PauseDynamics)
+TEST(MujocoModelTest, PauseDynamics)
 {
     using VectorN = gtfo::MujocoModel<7>::VectorN;
 
@@ -90,7 +96,7 @@ TEST(MujocoBasicModelsTest, PauseDynamics)
 }
 
 // Verify hard bound works with Mujoco model
-TEST(MujocoBasicModelsTest, HardBoundTest)
+TEST(MujocoModelTest, HardBoundTest)
 {
     using VectorN = gtfo::MujocoModel<7>::VectorN;
 
@@ -107,4 +113,47 @@ TEST(MujocoBasicModelsTest, HardBoundTest)
     EXPECT_TRUE(gtfo::IsEqual(system.GetPosition(), VectorN::Constant(0.1)));
     EXPECT_TRUE(gtfo::IsEqual(system.GetVelocity(), VectorN::Zero()));
     EXPECT_TRUE(gtfo::IsEqual(system.GetAcceleration(), VectorN::Zero()));
+}
+
+// Verify the rigid body dynamics with MuJoCo
+TEST(MujocoModelTest, RigidBodyDynamicsComparison)
+{   
+    using Vector3 = Eigen::Vector3d;
+    using Vector6 = Eigen::Matrix<double, 6, 1>;
+    using Quaternion = Eigen::Quaterniond;
+
+    // Load and create the MuJoCo model
+    EXPECT_TRUE(mjVERSION_HEADER == mj_version());
+    std::array<char, 1000> error;
+    mjModel* model = mj_loadXML("rectangle.xml", NULL, error.data(), 1000);
+    if(!model){
+        mju_error("Could not load model from file");
+    }
+    mjData* data = mj_makeData(model);
+    mj_step(model, data);
+
+    // Create the comparable gtfo model
+    gtfo::RigidBodySecondOrder<double> rigid_body(
+        model->opt.timestep,
+        model->body_mass[1],
+        Vector3::Map(&model->body_inertia[3]),
+        model->dof_damping[0],
+        model->dof_damping[3],
+        gtfo::Pose<double>(
+            Vector3::Map(&data->xpos[3]), 
+            Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]))
+    );
+
+    // Step the models together with the same input
+    const Vector6 input = (Vector6() << 0.3, -0.6, 0.0, 0.4, -0.5, 0.1).finished();
+    
+    Vector6::Map(data->ctrl) = input;
+    for(unsigned i = 0; i < 200; ++i){
+        mj_step(model, data);
+        rigid_body.Step(input);
+    }
+
+    // Evaluate that they are near each other
+    EXPECT_TRUE(gtfo::IsEqual(Vector3::Map(&data->xpos[3]), rigid_body.GetPose().GetPosition(), 0.002));
+    EXPECT_NEAR(Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]).angularDistance(rigid_body.GetPose().GetOrientation()), 0.0, M_PI / 36.0);
 }

--- a/Tests/RigidBodyDynamicsTest.cpp
+++ b/Tests/RigidBodyDynamicsTest.cpp
@@ -1,48 +1,5 @@
 #include <gtest/gtest.h>
-#include <mujoco/mujoco.h>
 #include "gtfo.hpp"
-
-TEST(RigidBodyDynamicsTest, MujocoComparison)
-{   
-    using Vector3 = Eigen::Vector3d;
-    using Vector6 = Eigen::Matrix<double, 6, 1>;
-    using Quaternion = Eigen::Quaterniond;
-
-    // Load and create the MuJoCo model
-    EXPECT_TRUE(mjVERSION_HEADER == mj_version());
-    std::array<char, 1000> error;
-    mjModel* model = mj_loadXML("rectangle.xml", NULL, error.data(), 1000);
-    if(!model){
-        mju_error("Could not load model from file");
-    }
-    mjData* data = mj_makeData(model);
-    mj_step(model, data);
-
-    // Create the comparable gtfo model
-    gtfo::RigidBodySecondOrder<double> rigid_body(
-        model->opt.timestep,
-        model->body_mass[1],
-        Vector3::Map(&model->body_inertia[3]),
-        model->dof_damping[0],
-        model->dof_damping[3],
-        gtfo::Pose<double>(
-            Vector3::Map(&data->xpos[3]), 
-            Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]))
-    );
-
-    // Step the models together with the same input
-    const Vector6 input = (Vector6() << 0.3, -0.6, 0.0, 0.4, -0.5, 0.1).finished();
-    
-    Vector6::Map(data->ctrl) = input;
-    for(unsigned i = 0; i < 200; ++i){
-        mj_step(model, data);
-        rigid_body.Step(input);
-    }
-
-    // Evaluate that they are near each other
-    EXPECT_TRUE(gtfo::IsEqual(Vector3::Map(&data->xpos[3]), rigid_body.GetPose().GetPosition(), 0.002));
-    EXPECT_NEAR(Quaternion(data->xquat[4], data->xquat[5], data->xquat[6], data->xquat[7]).angularDistance(rigid_body.GetPose().GetOrientation()), 0.0, M_PI / 36.0);
-}
 
 TEST(RigidBodyDynamicsTest, DynamicsVector)
 {  

--- a/include/gtfo.hpp
+++ b/include/gtfo.hpp
@@ -17,7 +17,7 @@
 #include "../Core/Models/HomingModel.hpp"
 #include "../Core/Models/ConstantVelocityModel.hpp"
 
-#ifdef MUJOCO_EXISTS
+#if __has_include(<mujoco/mujoco.h>)
     #include "../Core/Models/Mujoco/MujocoModel.hpp"
 #endif
 

--- a/include/gtfo.hpp
+++ b/include/gtfo.hpp
@@ -16,7 +16,10 @@
 #include "../Core/Models/RigidBodySecondOrder.hpp"
 #include "../Core/Models/HomingModel.hpp"
 #include "../Core/Models/ConstantVelocityModel.hpp"
-#include "../Core/Models/Mujoco/MujocoModel.hpp"
+
+#ifdef MUJOCO_EXISTS
+    #include "../Core/Models/Mujoco/MujocoModel.hpp"
+#endif
 
 #include "../Core/Bounds/NormBound.hpp"
 #include "../Core/Bounds/RectangleBound.hpp"


### PR DESCRIPTION
Made `MuJoCo` be an optional dependency, since not everyone may want to use `MujocoModel`. 