### PR TITLE
Spring and lock

### DIFF
--- a/Core/Models/PointMassBase.hpp
+++ b/Core/Models/PointMassBase.hpp
@@ -35,8 +35,7 @@ namespace gtfo
               B_discrete_(Eigen::Matrix<Scalar, 2, 1>::Zero()),
               C_discrete_(Eigen::Matrix<Scalar, 2, 1>::Zero()),
               soft_start_duration_(0.0),
-              soft_start_timer_(0.0),
-              initial_position_(initial_position)
+              soft_start_timer_(0.0)
         {
 
         }
@@ -93,7 +92,7 @@ namespace gtfo
             const Eigen::Matrix<Scalar, 2, Dimensions> state = (Eigen::Matrix<Scalar, 2, Dimensions>() << DynamicsModelBase::position_.transpose(), DynamicsModelBase::velocity_.transpose()).finished();
 
             // Step the dynamics to determine our next state
-            const Eigen::Matrix<Scalar, 2, Dimensions> new_state = A_discrete_ * state + B_discrete_ * force_input.transpose() + C_discrete_ * this->initial_position_.transpose();
+            const Eigen::Matrix<Scalar, 2, Dimensions> new_state = A_discrete_ * state + B_discrete_ * force_input.transpose() + C_discrete_ * parameters_.virtual_initial_position;
 
             // Update states
             DynamicsModelBase::position_ = new_state.row(0);
@@ -106,7 +105,6 @@ namespace gtfo
 
         Parameters parameters_;
         Parameters soft_start_parameters_;
-        VectorN initial_position_;
         Eigen::Matrix<Scalar, 2, 2> A_discrete_;
         Eigen::Matrix<Scalar, 2, 1> B_discrete_;
         Eigen::Matrix<Scalar, 2, 1> C_discrete_;

--- a/Core/Models/PointMassBase.hpp
+++ b/Core/Models/PointMassBase.hpp
@@ -33,8 +33,10 @@ namespace gtfo
               parameters_(parameters),
               A_discrete_(Eigen::Matrix<Scalar, 2, 2>::Zero()),
               B_discrete_(Eigen::Matrix<Scalar, 2, 1>::Zero()),
+              C_discrete_(Eigen::Matrix<Scalar, 2, 1>::Zero()),
               soft_start_duration_(0.0),
-              soft_start_timer_(0.0)
+              soft_start_timer_(0.0),
+              initial_position_(initial_position)
         {
 
         }
@@ -91,7 +93,7 @@ namespace gtfo
             const Eigen::Matrix<Scalar, 2, Dimensions> state = (Eigen::Matrix<Scalar, 2, Dimensions>() << DynamicsModelBase::position_.transpose(), DynamicsModelBase::velocity_.transpose()).finished();
 
             // Step the dynamics to determine our next state
-            const Eigen::Matrix<Scalar, 2, Dimensions> new_state = A_discrete_ * state + B_discrete_ * force_input.transpose();
+            const Eigen::Matrix<Scalar, 2, Dimensions> new_state = A_discrete_ * state + B_discrete_ * force_input.transpose() + C_discrete_ * this->initial_position_.transpose();
 
             // Update states
             DynamicsModelBase::position_ = new_state.row(0);
@@ -104,9 +106,10 @@ namespace gtfo
 
         Parameters parameters_;
         Parameters soft_start_parameters_;
-
+        VectorN initial_position_;
         Eigen::Matrix<Scalar, 2, 2> A_discrete_;
         Eigen::Matrix<Scalar, 2, 1> B_discrete_;
+        Eigen::Matrix<Scalar, 2, 1> C_discrete_;
 
     private:
         Scalar soft_start_duration_;

--- a/Core/Models/PointMassSecondOrder.hpp
+++ b/Core/Models/PointMassSecondOrder.hpp
@@ -65,7 +65,7 @@ namespace gtfo{
             
             // Calculate the acceleration using the more accurate continuous equations with the current velocity
             Base::acceleration_ = (-Base::parameters_.damping / Base::parameters_.mass) * Base::velocity_ + (-Base::parameters_.stiffness \
-            / Base:: parameters_.mass) * (Base::position_) + force_input / Base::parameters_.mass;
+            / Base:: parameters_.mass) * (Base::position_ - VectorN(Base::parameters_.virtual_initial_position)) + force_input / Base::parameters_.mass;
         }
 
     private:

--- a/Core/Models/PointMassSecondOrder.hpp
+++ b/Core/Models/PointMassSecondOrder.hpp
@@ -3,7 +3,7 @@
 // Desc: a second-order dynamics model
 //----------------------------------------------------------------------------------------------------
 #pragma once
-
+#include <cmath>
 // Project-specific
 #include "PointMassBase.hpp"
 
@@ -14,28 +14,31 @@ namespace gtfo{
     {
         Scalar mass;
         Scalar damping;
+        Scalar stiffness;
 
         SecondOrderParameters()
-            : ParametersBase<Scalar>(), mass(1.0), damping(1.0)
+            : ParametersBase<Scalar>(), mass(1.0), damping(1.0), stiffness(1.0)
         {
         }
 
-        SecondOrderParameters(const Scalar &dt, const Scalar &mass, const Scalar &damping)
-            : ParametersBase<Scalar>(dt), mass(mass), damping(damping)
+        SecondOrderParameters(const Scalar &dt, const Scalar &mass, const Scalar &damping, const Scalar &stiffness)
+            : ParametersBase<Scalar>(dt), mass(mass), damping(damping), stiffness(stiffness)
         {
-            assert(mass > 0.0 && damping > 0.0);
+            assert(mass > 0.0 && damping > 0.0 && stiffness > 0.0);
         }
 
         SecondOrderParameters operator+(const SecondOrderParameters& other){
             return SecondOrderParameters(ParametersBase<Scalar>::dt, 
                 mass + other.mass, 
-                damping + other.damping);
+                damping + other.damping,
+                stiffness + other.stiffness);
         }
 
         SecondOrderParameters operator*(const Scalar& scalar){
             return SecondOrderParameters(ParametersBase<Scalar>::dt, 
                 scalar * mass, 
-                scalar * damping);
+                scalar * damping,
+                scalar * stiffness);
         }
     };
 
@@ -58,7 +61,8 @@ namespace gtfo{
             Base::PropagateDynamics(force_input);
             
             // Calculate the acceleration using the more accurate continuous equations with the current velocity
-            Base::acceleration_ = (-Base::parameters_.damping / Base::parameters_.mass) * Base::velocity_ + force_input / Base::parameters_.mass;
+            Base::acceleration_ = (-Base::parameters_.damping / Base::parameters_.mass) * Base::velocity_ + (-Base::parameters_.stiffness \
+            / Base:: parameters_.mass) * Base::position_ +force_input / Base::parameters_.mass;
         }
 
     private:


### PR DESCRIPTION
I added a spring stiffness and virtual initial position into the second-order parameters.
It works when the virtual initial position is zero. I set the stiffness as 0.1 for joint 4, and drove it to a certain value in the simulation, and it slowly came back due to the effect of the spring. However, when I set the virtual initial condition as like 45 degrees, I found the joint will directly move to its upper joint limits (90 degrees). I think I already converted deg to rad. Would you mind having a look at the gtfo files I modified? Thank you so much!